### PR TITLE
ci: align Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     target-branch: main
     schedule:
       interval: weekly
+      day: sunday
+      time: '00:00'
+      timezone: Etc/UTC
     open-pull-requests-limit: 1
     groups:
       maven-all:
@@ -16,6 +19,9 @@ updates:
     target-branch: main
     schedule:
       interval: weekly
+      day: sunday
+      time: '00:00'
+      timezone: Etc/UTC
     open-pull-requests-limit: 1
     groups:
       actions-all:


### PR DESCRIPTION
Schedules grouped Dependabot updates for Sunday at 00:00 UTC before Monday maintenance.